### PR TITLE
more required fields

### DIFF
--- a/1-0-0/schema.json
+++ b/1-0-0/schema.json
@@ -43,13 +43,16 @@
                                 }
                             },
                             "required": [
-                                "flavor"
-                            ]
+                                "flavor",
+                                "interface"
+                            ],
+                            "additionalProperties": false
                         }
                     }
                 },
                 "required": [
                     "filename",
+                    "nolib",
                     "metadata"
                 ],
                 "additionalProperties": false


### PR DESCRIPTION
#4

* releases.nolib is now required.
* releases.metadata.interface is now required.
* releases.metadata no longer allows additional properties to be defined.